### PR TITLE
Changed method for hiding the admin bar

### DIFF
--- a/classes/Plugin.php
+++ b/classes/Plugin.php
@@ -87,7 +87,7 @@ class GravityFormsIframe_Plugin extends GravityFormsIframe_AbstractPlugin {
 		}
 
 		// Disable the toolbar in case the form is embedded on the same domain.
-		show_admin_bar( false );
+		add_filter( 'show_admin_bar', '__return_false', 100 );
 
 		require_once( GFCommon::get_base_path() . '/form_display.php' );
 


### PR DESCRIPTION
This (hopefully) should be a more reliable way to prevent the admin bar from showing up in form embeds. Fixes #44